### PR TITLE
Build swarm with TP5

### DIFF
--- a/windows/swarm-windows/Dockerfile
+++ b/windows/swarm-windows/Dockerfile
@@ -1,12 +1,12 @@
 # build windows swarm executable image
 # adapted from https://stefanscherer.github.io/build-docker-swarm-for-windows-the-docker-way/
 
-FROM windowsservercore:10.0.10586.0
+FROM windowsservercore:10.0.14300.1000
 
 # install chocolatey pkg mgr
 RUN @powershell -NoProfile -ExecutionPolicy unrestricted -Command "(iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))) >$null 2>&1" && SET PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin
 
-ENV SWARM_VERSION v1.1.3
+ENV SWARM_VERSION v1.2.2
 ENV GOROOT C:\\tools\\go
 ENV GOPATH C:\\work
 ENV SWARM_HOST :2375
@@ -21,8 +21,6 @@ COPY . .
 # cleanup to reduce image layer size
 RUN install-and-cleanup
 
-ENTRYPOINT powershell -Command \
-    sleep 2 ; \
-    \bin\swarm.exe
+ENTRYPOINT ["\\bin\\swarm.exe"]
 
 CMD ["--help"]


### PR DESCRIPTION
Update the Dockerfile to build with TP5.

This builds an Windows swarm image in one step. But even with the cleanup steps in the script the resulting image is much bigger (about 230MByte more than just the swarm.exe) than a two step approach like it is done in docker/swarm repo.

```
C:\Users\vagrant\labs\windows\swarm-windows [build-swarm-with-tp5 ≡]> docker images | sls swarm

swarm                         latest              43f5a8e2d656        7 minutes ago       9.691 GB
stefanscherer/swarm-windows   latest              3d7530263a13        13 days ago         9.455 GB
```

A two step approach can be found at https://github.com/StefanScherer/dockerfiles-windows/tree/master/swarm as well as some prebuilt swarm Docker images for Windows at https://hub.docker.com/r/stefanscherer/swarm-windows/
