### PR TITLE
Add scripts to build a docker 1.12-rc1 swarm

### DIFF
--- a/swarm/README.md
+++ b/swarm/README.md
@@ -1,0 +1,43 @@
+# docker swarm
+
+Get in touch with the new `docker swarm` feature in Docker 1.12.
+
+## Build a local swarm with Docker Machine
+
+To create a local swarm with Docker Machine use the following script
+
+```bash
+./buildswarm-vbox.sh
+```
+
+It will create two VirtualBox machines `sw01` and `sw02`. The machine `sw01` is
+the swarm manager, the machine `sw02` joins the swarm.
+
+To run further commands, just login to the machine `sw01` with
+
+```bash
+docker-machine ssh sw01
+```
+
+or run each command through ssh, eg.
+
+```bash
+docker-machine ssh sw01 docker node ls
+ID               NAME  MEMBERSHIP  STATUS  AVAILABILITY  MANAGER STATUS  LEADER
+0j9p42jcyur9a *  sw01  Accepted    Ready   Active        Reachable       Yes
+16cznbhxupre5    sw02  Accepted    Ready   Active                        
+```
+
+### Remote swarm with Docker Machine at DigitalOcean
+
+To build a multi machine swarm at DigitalOcean, run this script with your token.
+
+```bash
+DO_TOKEN=xxxx ./buildswarm-do.sh
+```
+
+Then control your swarm with commands on your swarm manager node
+
+```bash
+docker-machine ssh do-sw01 docker node ls
+```

--- a/swarm/buildswarm-do.sh
+++ b/swarm/buildswarm-do.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+LINK=https://test.docker.com/builds/Linux/x86_64/docker-1.12.0-rc1.tgz
+
+SIZE=2gb
+REGION=ams2
+IMAGE=ubuntu-15-10-x64
+
+PREFIX=do
+
+# create swarm manager
+docker-machine create \
+  --driver=digitalocean \
+  --digitalocean-access-token=${DO_TOKEN} \
+  --digitalocean-size=${SIZE} \
+  --digitalocean-region=${REGION} \
+  --digitalocean-private-networking=true \
+  --digitalocean-image=${IMAGE} \
+  ${PREFIX}-sw01
+echo "sudo /etc/init.d/docker stop && curl $LINK | tar xzf - && sudo mv docker/* /usr/bin && rm -rf docker/ && sudo /etc/init.d/docker start" | docker-machine ssh ${PREFIX}-sw01 sh -
+docker-machine ssh ${PREFIX}-sw01 docker swarm init
+
+# create another swarm node
+docker-machine create \
+  --driver=digitalocean \
+  --digitalocean-access-token=${DO_TOKEN} \
+  --digitalocean-size=${SIZE} \
+  --digitalocean-region=${REGION} \
+  --digitalocean-private-networking=true \
+  --digitalocean-image=${IMAGE} \
+  ${PREFIX}-sw02
+echo "sudo /etc/init.d/docker stop && curl $LINK | tar xzf - && sudo mv docker/* /usr/bin && rm -rf docker/ && sudo /etc/init.d/docker start" | docker-machine ssh ${PREFIX}-sw02 sh -
+docker-machine ssh ${PREFIX}-sw02 docker swarm join $(docker-machine ip ${PREFIX}-sw01):2377
+
+# list nodes
+docker-machine ssh ${PREFIX}-sw01 docker node ls

--- a/swarm/buildswarm-vbox.sh
+++ b/swarm/buildswarm-vbox.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+LINK=https://test.docker.com/builds/Linux/x86_64/docker-1.12.0-rc1.tgz
+
+# create swarm manager
+docker-machine create -d virtualbox sw01
+echo "sudo /etc/init.d/docker stop && curl $LINK | tar xzf - && sudo mv docker/* /usr/local/bin && rm -rf docker/ && sudo /etc/init.d/docker start" | docker-machine ssh sw01 sh -
+docker-machine ssh sw01 docker swarm init
+
+# create another swarm node
+docker-machine create -d virtualbox sw02
+echo "sudo /etc/init.d/docker stop && curl $LINK | tar xzf - && sudo mv docker/* /usr/local/bin && rm -rf docker/ && sudo /etc/init.d/docker start" | docker-machine ssh sw02 sh -
+docker-machine ssh sw02 docker swarm join $(docker-machine ip sw01):2377
+
+# list nodes
+docker-machine ssh sw01 docker node ls


### PR DESCRIPTION
I've built a small script `buildswarm-vbox.sh` to build a local multi machine swarm with docker-machine and the VirtualBox driver.

And there is a similar script `buildswarm-do.sh` to build a multi machine swarm at DigitalOcean.

This are helper scripts to get started with the new [Swarm Mode](https://github.com/docker/docker/releases/tag/v1.12.0-rc1) of Docker 1.12.0-rc1
