### PR TITLE
Simplify setup for 1.12.0-rc2

### DIFF
--- a/swarm/buildswarm-do.sh
+++ b/swarm/buildswarm-do.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-LINK=https://test.docker.com/builds/Linux/x86_64/docker-1.12.0-rc1.tgz
-
 SIZE=2gb
 REGION=ams2
 IMAGE=ubuntu-15-10-x64
@@ -15,8 +13,8 @@ docker-machine create \
   --digitalocean-region=${REGION} \
   --digitalocean-private-networking=true \
   --digitalocean-image=${IMAGE} \
+  --engine-install-url=https://test.docker.com \
   ${PREFIX}-sw01
-echo "sudo /etc/init.d/docker stop && curl $LINK | tar xzf - && sudo mv docker/* /usr/bin && rm -rf docker/ && sudo /etc/init.d/docker start" | docker-machine ssh ${PREFIX}-sw01 sh -
 docker-machine ssh ${PREFIX}-sw01 docker swarm init
 
 # create another swarm node
@@ -27,8 +25,8 @@ docker-machine create \
   --digitalocean-region=${REGION} \
   --digitalocean-private-networking=true \
   --digitalocean-image=${IMAGE} \
+  --engine-install-url=https://test.docker.com \
   ${PREFIX}-sw02
-echo "sudo /etc/init.d/docker stop && curl $LINK | tar xzf - && sudo mv docker/* /usr/bin && rm -rf docker/ && sudo /etc/init.d/docker start" | docker-machine ssh ${PREFIX}-sw02 sh -
 docker-machine ssh ${PREFIX}-sw02 docker swarm join $(docker-machine ip ${PREFIX}-sw01):2377
 
 # list nodes

--- a/swarm/buildswarm-vbox.sh
+++ b/swarm/buildswarm-vbox.sh
@@ -1,14 +1,12 @@
 #!/bin/bash
-LINK=https://test.docker.com/builds/Linux/x86_64/docker-1.12.0-rc1.tgz
+URL=https://github.com/boot2docker/boot2docker/releases/download/v1.12.0-rc2/boot2docker.iso
 
 # create swarm manager
-docker-machine create -d virtualbox sw01
-echo "sudo /etc/init.d/docker stop && curl $LINK | tar xzf - && sudo mv docker/* /usr/local/bin && rm -rf docker/ && sudo /etc/init.d/docker start" | docker-machine ssh sw01 sh -
+docker-machine create -d virtualbox --virtualbox-boot2docker-url $URL sw01
 docker-machine ssh sw01 docker swarm init
 
 # create another swarm node
-docker-machine create -d virtualbox sw02
-echo "sudo /etc/init.d/docker stop && curl $LINK | tar xzf - && sudo mv docker/* /usr/local/bin && rm -rf docker/ && sudo /etc/init.d/docker start" | docker-machine ssh sw02 sh -
+docker-machine create -d virtualbox --virtualbox-boot2docker-url $URL sw02
 docker-machine ssh sw02 docker swarm join $(docker-machine ip sw01):2377
 
 # list nodes


### PR DESCRIPTION
I've removed the ssh commands to the test binaries directly. Instead for VirtualBox the option `--virtualbox-boot2docker-url` is used, and for DO the option `--engine-install-url` is used to install Docker 1.12.0-rc2
