### PR TITLE
Add --listen-addr to swarm init to fix rejoining workers

### DIFF
--- a/swarm/buildswarm-do.sh
+++ b/swarm/buildswarm-do.sh
@@ -15,7 +15,7 @@ docker-machine create \
   --digitalocean-image=${IMAGE} \
   --engine-install-url=https://test.docker.com \
   ${PREFIX}-sw01
-docker-machine ssh ${PREFIX}-sw01 docker swarm init
+docker-machine ssh ${PREFIX}-sw01 docker swarm init --listen-addr $(docker-machine ip ${PREFIX}-sw01):2377
 
 # create another swarm node
 docker-machine create \
@@ -27,7 +27,7 @@ docker-machine create \
   --digitalocean-image=${IMAGE} \
   --engine-install-url=https://test.docker.com \
   ${PREFIX}-sw02
-docker-machine ssh ${PREFIX}-sw02 docker swarm join $(docker-machine ip ${PREFIX}-sw01):2377
+docker-machine ssh ${PREFIX}-sw02 docker swarm join --listen-addr $(docker-machine ip ${PREFIX}-sw02):2377 $(docker-machine ip ${PREFIX}-sw01):2377
 
 # list nodes
 docker-machine ssh ${PREFIX}-sw01 docker node ls

--- a/swarm/buildswarm-vbox.sh
+++ b/swarm/buildswarm-vbox.sh
@@ -3,11 +3,11 @@ URL=https://github.com/boot2docker/boot2docker/releases/download/v1.12.0-rc2/boo
 
 # create swarm manager
 docker-machine create -d virtualbox --virtualbox-boot2docker-url $URL sw01
-docker-machine ssh sw01 docker swarm init
+docker-machine ssh sw01 docker swarm init --listen-addr $(docker-machine ip sw01):2377
 
 # create another swarm node
 docker-machine create -d virtualbox --virtualbox-boot2docker-url $URL sw02
-docker-machine ssh sw02 docker swarm join $(docker-machine ip sw01):2377
+docker-machine ssh sw02 docker swarm join --listen-addr $(docker-machine ip sw02):2377 $(docker-machine ip sw01):2377
 
 # list nodes
 docker-machine ssh sw01 docker node ls


### PR DESCRIPTION
It seems that the `docker swarm init` must be followed by `--listen-addr` option to make failure scenarios work where a worker is killed and restarted.

Build a swarm without listen-addr option and kill and restart a worker. The worker does not come up to the 

```
URL=https://github.com/boot2docker/boot2docker/releases/download/v1.12.0-rc2/boot2docker.iso
docker-machine create -d virtualbox --virtualbox-boot2docker-url $URL sw01
docker-machine ssh sw01 docker swarm init
docker-machine create -d virtualbox --virtualbox-boot2docker-url $URL sw02
docker-machine ssh sw02 docker swarm join $(docker-machine ip sw01):2377
docker-machine ssh sw01 docker node ls
```

The worker has joined the swarm. Now kill the worker and wait until the manager lists the worker as "Down".

```
docker-machine kill sw02
docker-machine ssh sw01 docker node ls
```

Repeat the `docker node ls` until you see that the worker is down. Now restart the worker and check the nodes. Result: The worker still is "Down", even after a while.

```
docker-machine start sw02
docker-machine ssh sw01 docker node ls
```

By adding the `--listen-addr` to the swarm init command it seems to work. 

But why is there a difference? @mgoelzer any hints? Should we file an issue in docker/docker for that?
