### PR TITLE
Fix apparmor/seccomp check

### DIFF
--- a/security/apparmor/README.md
+++ b/security/apparmor/README.md
@@ -28,7 +28,7 @@ The following command shows you how to check if AppArmor is enabled in your syst
 
    Check from Docker 1.12 or higher
    ```
-   $ docker version | grep apparmor
+   $ docker info | grep apparmor
    Security Options: apparmor seccomp   
    ```
    If the above output does not return a line with `apparmor` then your system does not have AppArmor enabled in its kernel.

--- a/security/seccomp/README.md
+++ b/security/seccomp/README.md
@@ -26,7 +26,7 @@ The following commands show you how to check if seccomp is enabled in your syste
 
    Check from Docker 1.12 or higher
    ```
-   $ docker version | grep seccomp
+   $ docker info | grep seccomp
    Security Options: apparmor seccomp   
    ```
    If the above output does not return a line with `seccomp` then your system does not have seccomp enabled in its kernel.


### PR DESCRIPTION
Status of those security options are displayed with `docker info`, not `docker version`

Closes #102