### PR TITLE
security workshop fixes

### DIFF
--- a/security/apparmor/README.md
+++ b/security/apparmor/README.md
@@ -242,10 +242,11 @@ WordPress and its plugins run as PHP. This means an attacker could upload their 
 
 In this step we'll show how a custom AppArmor profile could have protected Dockerized WordPress from this attack vector.
 
-1.  If you have not already, `cd` into the lab's `wordpress` directory.
+1.  If you have not already, clone the lab and `cd` into the lab's `wordpress` directory.
 
    ```
-   $ cd dockercon-workshop/apparmor/wordpress
+   $ git clone https://github.com/docker/labs.git
+   $ cd labs/security/apparmor/wordpress
    ```
 
 2.  List the files in the directory.

--- a/security/cgroups/README.md
+++ b/security/cgroups/README.md
@@ -255,7 +255,7 @@ In this step you will use the `--pids-limit` flag to limit the number of process
 1. Start a new container and limit the number of processes it can create to 200 with the following command.
 
    ```
-   $ sudo docker run -rm -it --pids-limit 200 debian:jessie bash
+   $ sudo docker run --rm -it --pids-limit 200 debian:jessie bash
 
    Unable to find image 'debian:jessie' locally
    jessie: Pulling from library/debian

--- a/security/seccomp/README.md
+++ b/security/seccomp/README.md
@@ -45,10 +45,10 @@ Docker has used seccomp since version 1.10 of the Docker Engine.
 
 Docker uses seccomp in *filter mode* and has its own JSON-based DSL that allows you to define *profiles* that compile down to seccomp filters. When you run a container it gets the default seccomp profile unless you override this by passing the `--security-opt` flag to the `docker run` command.
 
-The following example command starts an interactive container based off the Alpine image and starts a shell process. It also applies the `default.json` seccomp profile to it.
+The following example command starts an interactive container based off the Alpine image and starts a shell process. It also applies the seccomp profile described by `<profile>.json` to it.
 
    ```
-   $ sudo docker run -it --rm --security-opt seccomp=default.json alpine sh ...
+   $ sudo docker run -it --rm --security-opt seccomp=<profile>.json alpine sh ...
    ```
 
 The above command sends the JSON file from the client to the daemon where it is compiled into a BPF program using a [thin Go wrapper around libseccomp](https://github.com/seccomp/libseccomp-golang).
@@ -75,7 +75,7 @@ In this step you will clone the lab's GitHub repo so that you have the seccomp p
    $ cd labs/security/seccomp
    ```
 
-The remaining steps in this lab will assume that you are running commands from this `dockercon-workshop/seccomp` directory. This will be important when referencing the seccomp profiles on the various `docker run` commands throughout the lab.
+The remaining steps in this lab will assume that you are running commands from this `labs/security/seccomp` directory. This will be important when referencing the seccomp profiles on the various `docker run` commands throughout the lab.
 
 # <a name="test"></a>Step 2: Test a seccomp profile
 


### PR DESCRIPTION
Various fixes to the security workshop.  Including:
- remove references to the old `dockercon-workshop` repo
- fix a docker `--rm` flag

cc @mschuchard 

Closes #108