### PR TITLE
Current description of EXPOSE command is misleading

### DIFF
--- a/beginner/chapters/webapps.md
+++ b/beginner/chapters/webapps.md
@@ -459,7 +459,11 @@ Here's a quick summary of the few basic commands we used in our Dockerfile.
   CMD ["/bin/bash", "echo", "Hello World"]
 ```
 
-* `EXPOSE` opens ports in your image to allow communication to the outside world when it runs in a container.
+* `EXPOSE` creates a hint for users of an image which ports provide services. It is included in the information which
+ can be retrieved via `$ docker inspect <container-id>`.     
+
+>**Note:** The `EXPOSE` command does not actually make any ports accessible to the host! Instead, this requires 
+publishing ports by means of the `-p` flag when using `$ docker run`.  
 
 * `PUSH` pushes your image to Docker Hub, or alternately to a [private registry](TODO: add URL)
 


### PR DESCRIPTION
Hi,
While skimming over the beginner labs, I came across the description of what the EXPOSE command means in terms of Dockerfiles and found that it doesn't match the command's actual behavior. The current version of the description says that the EXPOSE directive actually makes ports available to the underlying host, which is not true according to the docs. From the [docs](https://docs.docker.com/engine/reference/builder/#expose):

>   The EXPOSE instruction informs Docker that the container listens on the specified network ports at runtime. EXPOSE does not make the ports of the container accessible to the host.

I fixed the description for making that clear to readers.

Cheers,
Patrick