### PR TITLE
Fixing 'docker stack services' command syntax

### DIFF
--- a/beginner/chapters/votingapp.md
+++ b/beginner/chapters/votingapp.md
@@ -133,7 +133,7 @@ Creating service vote_worker
 Creating service vote_redis
 Creating service vote_db
 ```
-to verify your stack has deployed, use `docker stack services`
+to verify your stack has deployed, use `docker stack services vote`
 ```
 docker stack services vote
 ID            NAME         MODE        REPLICAS  IMAGE


### PR DESCRIPTION
The argument regarding the stack ('vote', in the example) was missing. Without it, the following error message was being displayed:
```
"docker stack services" requires exactly 1 argument(s).
See 'docker stack services --help'.

Usage:  docker stack services [OPTIONS] STACK

List the services in the stack
```