### PR TITLE
Use current Windows base image

### DIFF
--- a/windows/windows-containers/WindowsContainers.md
+++ b/windows/windows-containers/WindowsContainers.md
@@ -26,11 +26,10 @@ Server:
  OS/Arch:      windows/amd64
 ```
 
-Next, pull a base image that’s compatible with the evaluation build, re-tag it and do a test-run:
+Next, pull a base image that’s compatible with Windows and do a test-run:
 
 ```
-docker pull microsoft/windowsservercore:10.0.14393.321
-docker tag microsoft/windowsservercore:10.0.14393.321 microsoft/windowsservercore
+docker pull microsoft/windowsservercore
 docker run microsoft/windowsservercore hostname
 69c7de26ea48
 ```
@@ -62,7 +61,3 @@ Images stored on Docker Cloud are available in the web interface and public imag
 
 ### Next Steps
 Continue to Step 3: [Multi-Container Applications](MultiContainerApp.md "Multi-Container Applications")
-
-
-
-


### PR DESCRIPTION
I just walked through the Birthday labs for Windows and stopped at page http://birthday.play-with-docker.com/windows-containers-basics/

The following block is outdated and I thought how to improve it that we do not have to update it every month.

> Next, pull a base image that’s compatible with the evaluation build, re-tag it and do a test-run:
> 
> ```
> docker pull microsoft/windowsservercore:10.0.14393.321
> docker tag microsoft/windowsservercore:10.0.14393.321 microsoft/windowsservercore
> docker run microsoft/windowsservercore hostname
> 69c7de26ea48
> ```

The problem with it is that we educate to pull an outdated image and tag it as it were the latest. As Microsoft updates the base image and also the latest tag it would be better to help people to use the current image by just pulling it.
