### PR TITLE
README.md: fix broken HTTP Routing Mesh link

### DIFF
--- a/networking/README.md
+++ b/networking/README.md
@@ -19,6 +19,6 @@ This tutorial allows you to dive right in and try code in the [Quick Tutorials](
 1. [Networking Basics](A1-network-basics.md)
 1. [Bridge Networking](A2-bridge-networking.md)
 1. [Overlay Networking](A3-overlay-networking.md)
-1. [HTTP Routing Mesh](A4-HTTP Routing Mesh.md)
+1. [HTTP Routing Mesh](A4-HTTP%20Routing%20Mesh.md)
 
 Or you can first dive deep into the [Network Concepts](concepts/) before trying in out in code yourself.


### PR DESCRIPTION
Spaces in the filename caused markdown not to render link properly, works fine when urlencoded--as this PR proposes.

An alternative fix would be to rename ``labs/networking/A4-HTTP Routing Mesh.md``, substituting the ``<spaces>`` for hyphens--this would bring the file into alignment with all others in the directory.