### PR TITLE
Remove Broken Link

### DIFF
--- a/swarm-mode/beginner-tutorial/README.md
+++ b/swarm-mode/beginner-tutorial/README.md
@@ -387,5 +387,4 @@ Successfully removed manager3
 ```  
 
 ## Next steps
-We have a similar tutorial using Docker Machine to do [Service deployment on a swarm in the Cloud](../cloud-quick-start/README.md).
-Also check out the documentation on [Docker Swarm Mode](https://docs.docker.com/engine/swarm/) for more information.
+Check out the documentation on [Docker Swarm Mode](https://docs.docker.com/engine/swarm/) for more information.


### PR DESCRIPTION
The `cloud-quick-start` section seems to no longer exist. I've removed the note that talks about it