### PR TITLE
Update Dockerfile

### DIFF
--- a/windows/sql-server/Dockerfile
+++ b/windows/sql-server/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Elton Stoneman <elton@docker.com>
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
 
 EXPOSE 1433
-VOLUME c:\\database
+VOLUME c:\database
 ENV sa_password D0cker!a8s
 
 RUN md c:\init


### PR DESCRIPTION
the \\\\ doesn't seem to be mandatory anymore (tested on Docker For Windows & Docker 17.06) and gives me an error

Step 5/11 : VOLUME c:\\\\database
Unrecognised volume spec: invalid volume specification: 'c:\\\\database'

while 'c:\database' works fine

Step 5/11 : VOLUME c:\database
 ---> Running in 9815d433ef22