### PR TITLE
Updating node&npm + readme instructions & fixing general issues

### DIFF
--- a/developer-tools/nodejs-debugging/.gitignore
+++ b/developer-tools/nodejs-debugging/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.vscode

--- a/developer-tools/nodejs-debugging/VSCode-README.md
+++ b/developer-tools/nodejs-debugging/VSCode-README.md
@@ -115,8 +115,8 @@ A JSON file will be created and displayed. Replace its contents with the followi
             "address": "localhost",
             "restart": true,
             "sourceMaps": false,
-            "outDir": null,
-            "localRoot": "${workspaceRoot}",
+            "outFiles": [],
+            "localRoot": "${workspaceRoot}/app",
             "remoteRoot": "/code"
         }
     ]

--- a/developer-tools/nodejs-debugging/VSCode-README.md
+++ b/developer-tools/nodejs-debugging/VSCode-README.md
@@ -23,7 +23,7 @@ We've created a simple application which includes an error. You can see the app 
 Let's take a look at the `Dockerfile`:
 
 ```
-FROM node:5.11.0-slim
+FROM node:8.2.1
 
 WORKDIR /code
 
@@ -48,7 +48,7 @@ version: "3"
 services:
   web:
     build: .
-    command: nodemon --debug=5858
+    command: nodemon --inspect=0.0.0.0:5858
     volumes:
       - .:/code
     ports:
@@ -80,7 +80,7 @@ Attaching to nodeexample_web_1
 web_1  | [nodemon] 1.9.2
 web_1  | [nodemon] to restart at any time, enter `rs`
 web_1  | [nodemon] watching: *.*
-web_1  | [nodemon] starting `node --debug=5858 app.js`
+web_1  | [nodemon] starting `node --inspect=0.0.0.0:5858 app.js`
 web_1  | Debugger listening on port 5858
 web_1  | HTTP server listening on port 80
 ```

--- a/developer-tools/nodejs-debugging/app/.gitignore
+++ b/developer-tools/nodejs-debugging/app/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/developer-tools/nodejs-debugging/app/.gitignore
+++ b/developer-tools/nodejs-debugging/app/.gitignore
@@ -1,1 +1,0 @@
-node_modules

--- a/developer-tools/nodejs-debugging/app/Dockerfile
+++ b/developer-tools/nodejs-debugging/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:5.11.0-slim
+FROM node:8.2.1
 
 WORKDIR /code
 

--- a/developer-tools/nodejs-debugging/app/app.js
+++ b/developer-tools/nodejs-debugging/app/app.js
@@ -1,5 +1,5 @@
 var express = require('express');
-var expressHandlebars  = require('express-handlebars');
+var expressHandlebars = require('express-handlebars');
 var http = require('http');
 
 var PORT = 8000;

--- a/developer-tools/nodejs-debugging/app/docker-compose.yml
+++ b/developer-tools/nodejs-debugging/app/docker-compose.yml
@@ -3,7 +3,7 @@ version: "2"
 services:
   web:
     build: .
-    command: nodemon --inspect=0.0.0.0:5858
+    command: nodemon --inspect=5858
     volumes:
       - .:/code
     ports:

--- a/developer-tools/nodejs-debugging/app/docker-compose.yml
+++ b/developer-tools/nodejs-debugging/app/docker-compose.yml
@@ -3,7 +3,7 @@ version: "2"
 services:
   web:
     build: .
-    command: nodemon --debug=5858
+    command: nodemon --inspect=0.0.0.0:5858
     volumes:
       - .:/code
     ports:

--- a/developer-tools/nodejs-debugging/app/package-lock.json
+++ b/developer-tools/nodejs-debugging/app/package-lock.json
@@ -1,0 +1,615 @@
+{
+    "requires": true,
+    "lockfileVersion": 1,
+    "dependencies": {
+        "accepts": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+            "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
+            "requires": {
+                "mime-types": "2.1.16",
+                "negotiator": "0.6.1"
+            }
+        },
+        "align-text": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+            "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+            "requires": {
+                "kind-of": "3.2.2",
+                "longest": "1.0.1",
+                "repeat-string": "1.6.1"
+            }
+        },
+        "amdefine": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+            "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+        },
+        "array-flatten": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+            "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+        },
+        "asap": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+            "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+        },
+        "async": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+            "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        },
+        "balanced-match": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+        },
+        "brace-expansion": {
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+            "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+            "requires": {
+                "balanced-match": "1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "camelcase": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+            "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+            "optional": true
+        },
+        "center-align": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+            "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+            "optional": true,
+            "requires": {
+                "align-text": "0.1.4",
+                "lazy-cache": "1.0.4"
+            }
+        },
+        "cliui": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+            "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+            "optional": true,
+            "requires": {
+                "center-align": "0.1.3",
+                "right-align": "0.1.3",
+                "wordwrap": "0.0.2"
+            },
+            "dependencies": {
+                "wordwrap": {
+                    "version": "0.0.2",
+                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                    "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+                    "optional": true
+                }
+            }
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+        },
+        "content-disposition": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+            "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+        },
+        "content-type": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
+            "integrity": "sha1-t9ETrueo3Se9IRM8TcJSnfFyHu0="
+        },
+        "cookie": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+            "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+        },
+        "cookie-signature": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+            "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+        },
+        "debug": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+            "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+            "requires": {
+                "ms": "0.7.1"
+            }
+        },
+        "decamelize": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+            "optional": true
+        },
+        "define-properties": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+            "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+            "requires": {
+                "foreach": "2.0.5",
+                "object-keys": "1.0.11"
+            }
+        },
+        "depd": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+            "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+        },
+        "destroy": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+            "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+        },
+        "ee-first": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+            "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+        },
+        "encodeurl": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+            "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA="
+        },
+        "escape-html": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+            "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+        },
+        "etag": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
+            "integrity": "sha1-A9MLX2fdbmMtKUXTDWZScxo01dg="
+        },
+        "express": {
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.14.1.tgz",
+            "integrity": "sha1-ZGwjf3ZvFIwhIK/wc4F7nk1+DTM=",
+            "requires": {
+                "accepts": "1.3.3",
+                "array-flatten": "1.1.1",
+                "content-disposition": "0.5.2",
+                "content-type": "1.0.2",
+                "cookie": "0.3.1",
+                "cookie-signature": "1.0.6",
+                "debug": "2.2.0",
+                "depd": "1.1.1",
+                "encodeurl": "1.0.1",
+                "escape-html": "1.0.3",
+                "etag": "1.7.0",
+                "finalhandler": "0.5.1",
+                "fresh": "0.3.0",
+                "merge-descriptors": "1.0.1",
+                "methods": "1.1.2",
+                "on-finished": "2.3.0",
+                "parseurl": "1.3.1",
+                "path-to-regexp": "0.1.7",
+                "proxy-addr": "1.1.5",
+                "qs": "6.2.0",
+                "range-parser": "1.2.0",
+                "send": "0.14.2",
+                "serve-static": "1.11.2",
+                "type-is": "1.6.15",
+                "utils-merge": "1.0.0",
+                "vary": "1.1.1"
+            }
+        },
+        "express-handlebars": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/express-handlebars/-/express-handlebars-3.0.0.tgz",
+            "integrity": "sha1-gKBwu4GbCeSvLKbQeA91zgXnXC8=",
+            "requires": {
+                "glob": "6.0.4",
+                "graceful-fs": "4.1.11",
+                "handlebars": "4.0.10",
+                "object.assign": "4.0.4",
+                "promise": "7.3.1"
+            }
+        },
+        "finalhandler": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.1.tgz",
+            "integrity": "sha1-LEANjUUwk1vCMlScX6OF7Afeb80=",
+            "requires": {
+                "debug": "2.2.0",
+                "escape-html": "1.0.3",
+                "on-finished": "2.3.0",
+                "statuses": "1.3.1",
+                "unpipe": "1.0.0"
+            }
+        },
+        "foreach": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+            "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+        },
+        "forwarded": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
+            "integrity": "sha1-Ge+YdMSuHCl7zweP3mOgm2aoQ2M="
+        },
+        "fresh": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
+            "integrity": "sha1-ZR+DjiJCTnVm3hYdg1jKoZn4PU8="
+        },
+        "function-bind": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
+            "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E="
+        },
+        "glob": {
+            "version": "6.0.4",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+            "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+            "requires": {
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
+            }
+        },
+        "graceful-fs": {
+            "version": "4.1.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+        },
+        "handlebars": {
+            "version": "4.0.10",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
+            "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
+            "requires": {
+                "async": "1.5.2",
+                "optimist": "0.6.1",
+                "source-map": "0.4.4",
+                "uglify-js": "2.8.29"
+            }
+        },
+        "http-errors": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
+            "integrity": "sha1-eIwNLB3iyBuebowBhDtrl+uSB1A=",
+            "requires": {
+                "inherits": "2.0.3",
+                "setprototypeof": "1.0.2",
+                "statuses": "1.3.1"
+            }
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "requires": {
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
+            }
+        },
+        "inherits": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        },
+        "ipaddr.js": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.4.0.tgz",
+            "integrity": "sha1-KWrKh4qCGBbluF0KKFqZvP9FgvA="
+        },
+        "is-buffer": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+            "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
+        },
+        "kind-of": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+            "requires": {
+                "is-buffer": "1.1.5"
+            }
+        },
+        "lazy-cache": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+            "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+            "optional": true
+        },
+        "longest": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+            "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
+        },
+        "media-typer": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+            "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+        },
+        "merge-descriptors": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+            "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+        },
+        "methods": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+            "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+        },
+        "mime": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+            "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM="
+        },
+        "mime-db": {
+            "version": "1.29.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz",
+            "integrity": "sha1-SNJtI1WJZRcErFkWygYAGRQmaHg="
+        },
+        "mime-types": {
+            "version": "2.1.16",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
+            "integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
+            "requires": {
+                "mime-db": "1.29.0"
+            }
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "requires": {
+                "brace-expansion": "1.1.8"
+            }
+        },
+        "minimist": {
+            "version": "0.0.10",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+            "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+        },
+        "ms": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+            "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+        },
+        "negotiator": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+            "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+        },
+        "object-keys": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+            "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+        },
+        "object.assign": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz",
+            "integrity": "sha1-scnMBE7xuf5jYG/BQau7MuFHMMw=",
+            "requires": {
+                "define-properties": "1.1.2",
+                "function-bind": "1.1.0",
+                "object-keys": "1.0.11"
+            }
+        },
+        "on-finished": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+            "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+            "requires": {
+                "ee-first": "1.1.1"
+            }
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "requires": {
+                "wrappy": "1.0.2"
+            }
+        },
+        "optimist": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+            "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+            "requires": {
+                "minimist": "0.0.10",
+                "wordwrap": "0.0.3"
+            }
+        },
+        "parseurl": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+            "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY="
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+        },
+        "path-to-regexp": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+            "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+        },
+        "promise": {
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+            "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+            "requires": {
+                "asap": "2.0.6"
+            }
+        },
+        "proxy-addr": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.5.tgz",
+            "integrity": "sha1-ccDuOxAt4/IC87ZPYI0XP8uhqRg=",
+            "requires": {
+                "forwarded": "0.1.0",
+                "ipaddr.js": "1.4.0"
+            }
+        },
+        "qs": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz",
+            "integrity": "sha1-O3hIwDwt7OaalSKw+ujEEm10Xzs="
+        },
+        "range-parser": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+            "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+        },
+        "repeat-string": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+        },
+        "right-align": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+            "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+            "optional": true,
+            "requires": {
+                "align-text": "0.1.4"
+            }
+        },
+        "send": {
+            "version": "0.14.2",
+            "resolved": "https://registry.npmjs.org/send/-/send-0.14.2.tgz",
+            "integrity": "sha1-ObBDiz9RC+Xcb2Z6EfcWiTaM3u8=",
+            "requires": {
+                "debug": "2.2.0",
+                "depd": "1.1.1",
+                "destroy": "1.0.4",
+                "encodeurl": "1.0.1",
+                "escape-html": "1.0.3",
+                "etag": "1.7.0",
+                "fresh": "0.3.0",
+                "http-errors": "1.5.1",
+                "mime": "1.3.4",
+                "ms": "0.7.2",
+                "on-finished": "2.3.0",
+                "range-parser": "1.2.0",
+                "statuses": "1.3.1"
+            },
+            "dependencies": {
+                "ms": {
+                    "version": "0.7.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+                    "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
+                }
+            }
+        },
+        "serve-static": {
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.2.tgz",
+            "integrity": "sha1-LPmIm9RDWjIMw2iVyapXvWYuasc=",
+            "requires": {
+                "encodeurl": "1.0.1",
+                "escape-html": "1.0.3",
+                "parseurl": "1.3.1",
+                "send": "0.14.2"
+            }
+        },
+        "setprototypeof": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz",
+            "integrity": "sha1-gaVSFB7BBLiOic44MQOtXGZWTQg="
+        },
+        "source-map": {
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+            "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+            "requires": {
+                "amdefine": "1.0.1"
+            }
+        },
+        "statuses": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+            "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+        },
+        "type-is": {
+            "version": "1.6.15",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
+            "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
+            "requires": {
+                "media-typer": "0.3.0",
+                "mime-types": "2.1.16"
+            }
+        },
+        "uglify-js": {
+            "version": "2.8.29",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+            "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+            "optional": true,
+            "requires": {
+                "source-map": "0.5.6",
+                "uglify-to-browserify": "1.0.2",
+                "yargs": "3.10.0"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.5.6",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+                    "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+                    "optional": true
+                }
+            }
+        },
+        "uglify-to-browserify": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+            "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+            "optional": true
+        },
+        "unpipe": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+            "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+        },
+        "utils-merge": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+            "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
+        },
+        "vary": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz",
+            "integrity": "sha1-Z1Neu2lMHVIldFeYRmUyP1h+jTc="
+        },
+        "window-size": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+            "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+            "optional": true
+        },
+        "wordwrap": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+            "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+        },
+        "yargs": {
+            "version": "3.10.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+            "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+            "optional": true,
+            "requires": {
+                "camelcase": "1.2.1",
+                "cliui": "2.1.0",
+                "decamelize": "1.2.0",
+                "window-size": "0.1.0"
+            }
+        }
+    }
+}


### PR DESCRIPTION
A few updates and fixes to this tutorial I found I needed to do with the latest vscode, node and npm.

- Upgrade to node 8.2.1 and with it node inspector + package.lock file with updated npm
- Fixed attach not working without 0.0.0.0:
- Fixed breakpoints not hitting without the correct localRoot path
