### PR TITLE
fix a typo

### DIFF
--- a/networking/concepts/06-overlay-networks.md
+++ b/networking/concepts/06-overlay-networks.md
@@ -18,7 +18,7 @@ In this diagram we see the packet flow on an overlay network. Here are the steps
 
 - `c1` does a DNS lookup for `c2`. Since both containers are on the same overlay network the Docker Engine local DNS server resolves `c2` to its overlay IP address `10.0.0.3`.
 - An overlay network is a L2 segment so `c1` generates an L2 frame destined for the MAC address of `c2`.
-- The frame is encapsulated with a VXLAN header by the `overlay` network driver. The distributed overlay control plane manages the locations and state of each VXLAN tunnel endpoint so it knows that `c2` resides on `host-B` at the physical address of `192.168.0.3`. That address becomes the destination address of the underlay IP header.
+- The frame is encapsulated with a VXLAN header by the `overlay` network driver. The distributed overlay control plane manages the locations and state of each VXLAN tunnel endpoint so it knows that `c2` resides on `host-B` at the physical address of `192.168.1.3`. That address becomes the destination address of the underlay IP header.
 - Once encapsulated the packet is sent. The physical network is responsible of routing or bridging the VXLAN packet to the correct host.
 - The packet arrives at the `eth0` interface of `host-B` and is decapsulated by the `overlay` network driver. The original L2 frame from `c1` is passed to the `c2`'s `eth0` interface and up to the listening application.
 


### PR DESCRIPTION
![packetwalk.png](https://github.com/docker/labs/blob/master/networking/concepts/img/packetwalk.png?raw=true)
In [this](https://github.com/docker/labs/blob/master/networking/concepts/img/packetwalk.png) diagram, `host-B` 's `eth0` 's physical IP adress is `192.168.1.3`.