### PR TITLE
Adding target for ADD

### DIFF
--- a/developer-tools/java/chapters/ch03-build-image-java-9.adoc
+++ b/developer-tools/java/chapters/ch03-build-image-java-9.adoc
@@ -21,7 +21,7 @@ Use the following contents:
 # A JDK 9 with Debian slim
 FROM debian:stable-slim
 # Download from http://jdk.java.net/9/
-# ADD http://download.java.net/java/GA/jdk9/9/binaries/openjdk-9_linux-x64_bin.tar.gz
+# ADD http://download.java.net/java/GA/jdk9/9/binaries/openjdk-9_linux-x64_bin.tar.gz /opt
 ADD openjdk-9_linux-x64_bin.tar.gz /opt
 # Set up env variables
 ENV JAVA_HOME=/opt/jdk-9


### PR DESCRIPTION
Hi @arun-gupta ,
Just a suggestion to add the target to the line of downloading the JDK9. Potentially consider making this line (with the download) the not-commented option to ensure the Dockerfile works first time a build is attempted.
Thanks,
Peter Dam