### PR TITLE
Extract the tar

### DIFF
--- a/developer-tools/java/chapters/ch03-build-image-java-9.adoc
+++ b/developer-tools/java/chapters/ch03-build-image-java-9.adoc
@@ -22,7 +22,9 @@ Use the following contents:
 FROM debian:stable-slim
 # Download from http://jdk.java.net/9/
 # ADD http://download.java.net/java/GA/jdk9/9/binaries/openjdk-9_linux-x64_bin.tar.gz
-ADD openjdk-9_linux-x64_bin.tar.gz /opt
+COPY openjdk-9_linux-x64_bin.tar.gz /opt/
+RUN tar -xzf /opt/openjdk-9_linux-x64_bin.tar.gz -C /opt/ && \
+      rm /opt/openjdk-9_linux-x64_bin.tar.gz
 # Set up env variables
 ENV JAVA_HOME=/opt/jdk-9
 ENV PATH=$PATH:$JAVA_HOME/bin
@@ -30,6 +32,7 @@ CMD ["jshell", "-J-XX:+UnlockExperimentalVMOptions", \
                "-J-XX:+UseCGroupMemoryLimitForHeap", \
                "-R-XX:+UnlockExperimentalVMOptions", \
                "-R-XX:+UseCGroupMemoryLimitForHeap"]
+
 ----
 
 This image uses `debian` slim as the base image and installs the OpenJDK build


### PR DESCRIPTION
Hi @arun-gupta ,

I think we will need to extract the JDK before we can continue with building the Docker image.

Thanks,
Peter Dam