### PR TITLE
Remove note on IntelliJ compatibility with Docker

### DIFF
--- a/developer-tools/java/chapters/ch07-intellij.adoc
+++ b/developer-tools/java/chapters/ch07-intellij.adoc
@@ -11,8 +11,6 @@ This chapter will show you basic Docker tooling with IntelliJ IDEA:
 - Run, stop, delete a Container
 - Build an Image
 
-NOTE: IntelliJ only supports configuring Docker Engine running using Docker Toolbox. This means that if you are running Docker for Mac or Docker for Windows then IntelliJ cannot be used.
-
 === Install Docker Plugin in IDEA
 
 Go to "`Preferences`", "`Plugins`", "`Install JetBrains plugin...`", search on "`docker`" and click on "`Install`"


### PR DESCRIPTION
Hi @arun-gupta, 
According to the docs and my practical experience, IntelliJ is compatible with Docker for Mac and Docker for Windows without any restrictions.

See also:
* https://www.jetbrains.com/help/idea/docker.html
* https://plugins.jetbrains.com/plugin/7724-docker-integration (Version 2.5.0)