### PR TITLE
Use nodemon -L in example app

### DIFF
--- a/developer-tools/nodejs-debugging/app/docker-compose.yml
+++ b/developer-tools/nodejs-debugging/app/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3"
 services:
   web:
     build: .
-    command: nodemon --inspect=0.0.0.0:5858
+    command: nodemon -L --inspect=0.0.0.0:5858
     volumes:
       - .:/code
     ports:


### PR DESCRIPTION
Small follow-up for #382, we should also use `nodemon -L` in the real app example to make Windows users happy. Just tried it on Windows 10 Insider 17046 with Docker 4 Windows 17.11.0 and the localhost port forwarding is just awesome!

<img width="1440" alt="bildschirmfoto 2017-11-29 um 12 48 04" src="https://user-images.githubusercontent.com/207759/33373958-73d7a484-d504-11e7-96d3-ba2f231fa907.png">
