### PR TITLE
Use official golang, fix trailing space

### DIFF
--- a/windows/registry/Dockerfile.builder
+++ b/windows/registry/Dockerfile.builder
@@ -1,13 +1,9 @@
 # escape=`
 
-# REMARK - when Go 1.8 is released we can use an official image for the base. 
-# There is an issue with Go 1.7 and Windows 2016 SYMLINKD directories which causes Docker volumes and host mounts to fail. 
-# This registry build uses a custom build of Go (@a2bd5c5) from the master branch to fix - https://github.com/golang/go/issues/15978
-
-FROM sixeyed/golang:windowsservercore 
+FROM golang:windowsservercore
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
 
-CMD .\go get github.com/docker/distribution/cmd/registry ; `    
+CMD go get github.com/docker/distribution/cmd/registry ; `
     cp \"$env:GOPATH\bin\registry.exe\" c:\out\ ; `
     cp \"$env:GOPATH\src\github.com\docker\distribution\cmd\registry\config-example.yml\" c:\out\config.yml
 

--- a/windows/registry/part-1.md
+++ b/windows/registry/part-1.md
@@ -31,7 +31,7 @@ The base image is the [official Go image](https://store.docker.com/images/golang
 There's a single `CMD` instruction to build the latest version of the registry and copy the built files to a known output location:
 
 ```Dockerfile
-CMD .\go get github.com/docker/distribution/cmd/registry ; `
+CMD go get github.com/docker/distribution/cmd/registry ; `
     cp \"$env:GOPATH\bin\registry.exe\" c:\out\ ; `
     cp \"$env:GOPATH\src\github.com\docker\distribution\cmd\registry\config-example.yml\" c:\out\config.yml
 ```

--- a/windows/registry/part-1.md
+++ b/windows/registry/part-1.md
@@ -22,18 +22,16 @@ The Dockerfile for the registry builder is in [Dockerfile.builder](Dockerfile.bu
 
 ```Dockerfile
 # escape=`
-FROM sixeyed/golang:windowsservercore 
+FROM golang:nanoserver
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
 ```
 
-The base image is [sixeyed/golang](https://store.docker.com/community/images/sixeyed/golang) which is in the Docker Store, built from [this Dockerfile](https://github.com/sixeyed/dockers-windows/blob/master/golang/Dockerfile). It has the Go toolset installed, but rather than using a released version, it builds Go from the source on GitHub to get the latest features.
-
-> Note. There is an [official Go image](https://store.docker.com/images/golang) on Docker Store, which has Windows Server Core and Nano Server variants. That uses the latest release of Go - 1.7 - which has [an issue](https://github.com/golang/go/issues/15978) that stops you using Docker volumes on Windows. It's fixed in the latest source code, which is why we use an image that builds from source, but when Go 1.8 is released we can switch to using the official image as the base for the builder.
+The base image is the [official Go image](https://store.docker.com/images/golang) which is in the Docker Store.
 
 There's a single `CMD` instruction to build the latest version of the registry and copy the built files to a known output location:
 
 ```Dockerfile
-CMD .\go get github.com/docker/distribution/cmd/registry ; `    
+CMD .\go get github.com/docker/distribution/cmd/registry ; `
     cp \"$env:GOPATH\bin\registry.exe\" c:\out\ ; `
     cp \"$env:GOPATH\src\github.com\docker\distribution\cmd\registry\config-example.yml\" c:\out\config.yml
 ```
@@ -44,7 +42,7 @@ When we run a container from the builder image, it will compile the latest regis
 
 First we build the builder image - all the images in this lab use [microsoft/windowsservercore](https://store.docker.com/images/windowsservercore) or [microsoft/nanoserver](https://store.docker.com/images/nanoserver) as the base images, so you can only use a Windows host to build and run them. From a PowerShell session, navigate to the lab folder and build the builder:
 
-```PowerShell 
+```PowerShell
 docker build -t registry-builder -f Dockerfile.builder .
 ```
 

--- a/windows/registry/part-1.md
+++ b/windows/registry/part-1.md
@@ -22,7 +22,7 @@ The Dockerfile for the registry builder is in [Dockerfile.builder](Dockerfile.bu
 
 ```Dockerfile
 # escape=`
-FROM golang:nanoserver
+FROM golang:windowsservercore
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
 ```
 


### PR DESCRIPTION
Update to official golang 1.9 which has the fix included.
Fix trailing spaces
Fixes #295 