### PR TITLE
Changed command to stop the container

### DIFF
--- a/developer-tools/java/chapters/ch10-monitoring.adoc
+++ b/developer-tools/java/chapters/ch10-monitoring.adoc
@@ -307,7 +307,7 @@ image::prometheus-metrics5.png[]
 +
 image::prometheus-metrics6.png[]
 +
-. Stop the container: `docker container rm -f metrics`
+. Stop the container: `docker service rm metrics`
 
 Multiple graphs can be added this way.
 


### PR DESCRIPTION
This issue was raised by @bvdriel and the issue can be seen here #357. The previous command, `docker container rm -f metrics` was not stopping the service therefore it wasn't working.