### PR TITLE
Update ch03-build-image-java-9.adoc

### DIFF
--- a/developer-tools/java/chapters/ch03-build-image-java-9.adoc
+++ b/developer-tools/java/chapters/ch03-build-image-java-9.adoc
@@ -332,7 +332,7 @@ that in application Docker image.
 Create a custom Java runtime that is small and only contains the `java.base`
 module:
 
-    docker container run --rm \
+    docker run --rm \
       --volume $PWD:/out \
       jdk-9-debian-slim \
       jlink --module-path /opt/jdk-9/jmods \


### PR DESCRIPTION
remove "container" from the copy of "create-minimal-java-runtime.sh" because it isn't in that file and that command doesn't create the target/openjdk-9-base_linux-x64 directory when it includes "container"