### PR TITLE
[12 factor] Fix Redis env configuration 

### DIFF
--- a/12factor/06_processes.md
+++ b/12factor/06_processes.md
@@ -52,11 +52,13 @@ services:
       - "8000:80"
     links:
       - mongo
+      - kv
     depends_on:
       - mongo
+      - kv
     environment:
       - MONGO_URL=mongodb://mongo/messageApp
-      - REDIS_URL=redis
+      - REDIS_HOST=kv
 volumes:
   mongo-data:
   redis-data:

--- a/12factor/07_port_binding.md
+++ b/12factor/07_port_binding.md
@@ -31,11 +31,13 @@ services:
       - "8000:80"     // app service is exposed on the port 8000 of the host
     links:
       - mongo
+      - kv
     depends_on:
       - mongo
+      - kv
     environment:
       - MONGO_URL=mongodb://mongo/messageApp
-      - REDIS_URL=redis
+      - REDIS_HOST=kv
 volumes:
   mongo-data:
   redis-data:


### PR DESCRIPTION
In 12 factor [6 - Processes](https://github.com/docker/labs/blob/master/12factor/06_processes.md) section we define redis host equal to `REDIS_HOST` environment variable
```
host: process.env.REDIS_HOST || 'localhost',
```

In docker compose we define Redis server with name `kv`:
```
  kv:
    image: redis:alpine
```

But further in the app declaration, we provide redis environment variable with name `REDIS_URL` (instead of `REDIS_HOST`) and value `redis` (instead of `kv`). 

The PR is fixing dependency configuration between app and redis