### PR TITLE
add missing start script

### DIFF
--- a/developer-tools/nodejs-debugging/app/package.json
+++ b/developer-tools/nodejs-debugging/app/package.json
@@ -1,5 +1,8 @@
 {
     "main": "app.js",
+    "scripts": {
+        "start": "node app.js"
+    },
     "dependencies": {
         "express": "~4.14.0",
         "express-handlebars": "~3.0.0"


### PR DESCRIPTION
I had the following error, when running the dockerfile:

```
npm info it worked if it ends with ok
npm info using npm@5.3.0
npm info using node@v8.2.1
npm ERR! missing script: start

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2019-08-16T06_22_09_424Z-debug.log
```