### PR TITLE
completed the list of official images

### DIFF
--- a/beginner/chapters/webapps.md
+++ b/beginner/chapters/webapps.md
@@ -157,7 +157,7 @@ An important distinction with regard to images is between _base images_ and _chi
 
 Another key concept is the idea of _official images_ and _user images_. (Both of which can be base images or child images.)
 
-- **Official images** are Docker sanctioned images. Docker, Inc. sponsors a dedicated team that is responsible for reviewing and publishing all Official Repositories content. This team works in collaboration with upstream software maintainers, security experts, and the broader Docker community. These are not prefixed by an organization or user name. In the list of images above, the `python`, `node`, `alpine` and `nginx` images are official (base) images. To find out more about them, check out the [Official Images Documentation](https://docs.docker.com/docker-hub/official_repos/).
+- **Official images** are Docker sanctioned images. Docker, Inc. sponsors a dedicated team that is responsible for reviewing and publishing all Official Repositories content. This team works in collaboration with upstream software maintainers, security experts, and the broader Docker community. These are not prefixed by an organization or user name. In the list of images above, the `nginx`, `python`, `postgres`, `node`, `redis`, `mongo`, and `alpine` images are official (base) images. To find out more about them, check out the [Official Images Documentation](https://docs.docker.com/docker-hub/official_repos/).
 
 - **User images** are images created and shared by users like you. They build on base images and add additional functionality. Typically these are formatted as `user/image-name`. The `user` value in the image name is your Docker Store user or organization name.
 


### PR DESCRIPTION
Also sorted the list of official images in the order that they appear in the further above `docker images` output for better readability.