### PR TITLE
fix-UserSignup

### DIFF
--- a/developer-tools/java-debugging/app/pom.xml
+++ b/developer-tools/java-debugging/app/pom.xml
@@ -58,7 +58,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-jpa</artifactId>
-			<version>1.11.23.RELEASE</version>
+			<version>1.3.0.RELEASE</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.springframework</groupId>

--- a/developer-tools/java-debugging/docker-compose.yml
+++ b/developer-tools/java-debugging/docker-compose.yml
@@ -22,6 +22,8 @@ services:
     # mount point for application in tomcat
     volumes:
       - ./app/target/UserSignup:/usr/local/tomcat/webapps/UserSignup
+      # for checking logs in host conveniently
+      - ./app/logs:/usr/local/tomcat/logs
     links:
       - database:registration-database
     # open ports for tomcat and remote debugging


### PR DESCRIPTION
rollback spring-data-jpa version changed at
https://github.com/docker/labs/pull/476/commits/dcd42c69fb9e810e7194ba27a55e0c25597a5e90
because  [/UserSignup] startup failed due to exception caused by: java.lang.NoSuchMethodError: org.springframework.beans.factory.xml.XmlReaderContext.getEnvironment()