### PR TITLE
Spring Data JPA Update for Java Dev Tools Debugging App

### DIFF
--- a/developer-tools/java-debugging/app/pom.xml
+++ b/developer-tools/java-debugging/app/pom.xml
@@ -5,14 +5,14 @@
 	<groupId>com.docker</groupId>
 	<artifactId>UserSignup</artifactId>
 	<packaging>war</packaging>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>0.0.2-SNAPSHOT</version>
 	<name>UserSignup Maven Webapp</name>
 	<url>http://maven.apache.org</url>
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-webmvc</artifactId>
-			<version>3.2.4.RELEASE</version>
+			<version>${spring.release}</version>
 		</dependency>
 		<dependency>
 			<groupId>javax.servlet</groupId>
@@ -48,12 +48,12 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-jdbc</artifactId>
-			<version>3.2.0.RELEASE</version>
+			<version>${spring.release}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-orm</artifactId>
-			<version>3.2.0.RELEASE</version>
+			<version>${spring.release}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.data</groupId>
@@ -66,10 +66,17 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+		<dependency>
+                  <groupId>org.slf4j</groupId>
+                  <artifactId>slf4j-simple</artifactId>
+                  <version>1.6.2</version>
+                </dependency>
 	</dependencies>
 	<properties>
-		<maven.compiler.source>1.7</maven.compiler.source>
-		<maven.compiler.target>1.7</maven.compiler.target>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<spring.release>4.3.25.RELEASE</spring.release>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
 	<build>
 		<finalName>UserSignup</finalName>


### PR DESCRIPTION
The GitHub Dependabot upgraded the Spring Data JPA dependency to the most current 1.x line of development. This created a need to upgrade the Spring version to `4.3.25.RELEASE`. This PR corrects that. Additionally the PR provides encoding, source compile, and logging updates, i.e., UTF-8 encoding warnings are resolved, the source target is 1.8, and adding the SLF4J Simple dependency improves logging and error resolution via `docker logs`.