### PR TITLE
Nodejs documentation updates

### DIFF
--- a/12factor/03_configuration.md
+++ b/12factor/03_configuration.md
@@ -4,7 +4,7 @@ Configuration (credentials, database connection string, ...) should be stored in
 
 ## What does that mean for our application ?
 
-In _config/connections.js_, we define the _mongo_ connection and use MONGO_URL environment variable to pass the mongo connection string.
+In _config/datastores.js_, we define the _mongo_ connection and use MONGO_URL environment variable to pass the mongo connection string.
 
 ```node
 module.exports.connections = {

--- a/developer-tools/nodejs/porting/1_node_application.md
+++ b/developer-tools/nodejs/porting/1_node_application.md
@@ -2,7 +2,7 @@
 
 ## Application details
 
-* API HTTP Rest based on Node.js / [Sails.js](sailsjs.org)) and [MongoDB](https://www.mongodb.com/)
+* API HTTP Rest based on Node.js / [Sails.js](sailsjs.com)) and [MongoDB](https://www.mongodb.com/)
 * A couple of prerequisites are needed to run the application locally
   * [Node.js 4.4.5 (LTS)](https://nodejs.org/en/)
   * [mongo 3.2](https://docs.mongodb.org/manual/installation/)
@@ -33,7 +33,7 @@ connection: 'mongo',
 ```
 
 ```
-config/connections.js:
+config/datastores.js:
 module.exports.connections = {
   mongo: {
      adapter: 'sails-mongo',


### PR DESCRIPTION
There are a couple of out of date references. This patch is a recommendation to update as per the current documentation:

 - Updated the url for sails.js from sailsjs.org -> sailsjs.com

 - In the current version of the documentation for SailsJS it appears that the function has been updated to be datastores.js instead of connections.js  (https://sailsjs.com/documentation/reference/configuration/sails-config-datastores)

