### PR TITLE
Fix: nodejs-debugging tutorial has no bug.

### DIFF
--- a/developer-tools/nodejs-debugging/app/app.js
+++ b/developer-tools/nodejs-debugging/app/app.js
@@ -21,7 +21,7 @@ app.get('/', function(req, res) {
     var message = LINES[lineIndex];
 
     lineIndex += 1;
-    if (lineIndex >= LINES.length) {
+    if (lineIndex > LINES.length) {
         lineIndex = 0;
     }
 


### PR DESCRIPTION
The source code from repo doesn't match tutorial instructions:

https://github.com/docker/labs/blob/master/developer-tools/nodejs-debugging/VSCode-README.md#start-debugging

On step "Fix the bug", source code from app already has = signal in the conditional statement:

https://github.com/docker/labs/blob/master/developer-tools/nodejs-debugging/VSCode-README.md#fix-the-bug