### PR TITLE
Added reason to use -it flag

### DIFF
--- a/beginner/chapters/alpine.md
+++ b/beginner/chapters/alpine.md
@@ -53,7 +53,7 @@ $ docker run alpine /bin/sh
 
 Wait, nothing happened! Is that a bug? Well, no. These interactive shells will exit after running any scripted commands, unless they are run in an interactive terminal - so for this example to not exit, you need to `docker run -it alpine /bin/sh`.
 
-Notice the `-it` flag in this modified command. The flag `-i` tells docker daemon to start an interactive session and `-t` command tells docker to attach the terminal of the container to the current terminal. 
+Notice the `-it` flag in this modified command. The flag `-i` tells the Docker daemon to start an interactive session, and `-t` command tells the Docker to attach the terminal of the container to the current terminal. 
 
 You are now inside the container shell and you can try out a few commands like `ls -l`, `uname -a` and others. Exit out of the container by giving the `exit` command.
 

--- a/beginner/chapters/alpine.md
+++ b/beginner/chapters/alpine.md
@@ -53,7 +53,7 @@ $ docker run alpine /bin/sh
 
 Wait, nothing happened! Is that a bug? Well, no. These interactive shells will exit after running any scripted commands, unless they are run in an interactive terminal - so for this example to not exit, you need to `docker run -it alpine /bin/sh`.
 
-Notice the `-it` flag in this modified command. The flag `-i` tells docker daemon to start an iterative session and `-t` command tells docker to attach the terminal of container to the current terminal. 
+Notice the `-it` flag in this modified command. The flag `-i` tells docker daemon to start an interactive session and `-t` command tells docker to attach the terminal of the container to the current terminal. 
 
 You are now inside the container shell and you can try out a few commands like `ls -l`, `uname -a` and others. Exit out of the container by giving the `exit` command.
 

--- a/beginner/chapters/alpine.md
+++ b/beginner/chapters/alpine.md
@@ -53,6 +53,8 @@ $ docker run alpine /bin/sh
 
 Wait, nothing happened! Is that a bug? Well, no. These interactive shells will exit after running any scripted commands, unless they are run in an interactive terminal - so for this example to not exit, you need to `docker run -it alpine /bin/sh`.
 
+Notice the `-it` flag in this modified command. The flag `-i` tells docker daemon to start an iterative session and `-t` command tells docker to attach the terminal of container to the current terminal. 
+
 You are now inside the container shell and you can try out a few commands like `ls -l`, `uname -a` and others. Exit out of the container by giving the `exit` command.
 
 


### PR DESCRIPTION
Line number 54 in /labs/blob/master/beginner/chapters/alpine.md does not clarify what we have changed in the new command to make the container to run the command interactively.
It would make more sense to the beginners if we tell them how the following command differs from the previous one and what makes the container interactive.